### PR TITLE
Fix SweepGA filtering: remove min_block_length constraint

### DIFF
--- a/src/aligner/sweepga_impl.rs
+++ b/src/aligner/sweepga_impl.rs
@@ -140,9 +140,11 @@ impl Aligner for SweepgaAligner {
             eprintln!("[sweepga] FastGA produced {} raw alignments", line_count);
         }
 
-        // Step 3: Apply 1:1 plane sweep filtering for clean graph construction
+        // Step 3: Apply plane sweep filtering with 1:1 mode for graph construction
+        // This keeps one best mapping per query-target pair while allowing
+        // multiple mappings per sequence (needed for graph construction)
         if self.verbose {
-            eprintln!("[sweepga] Applying 1:1 plane sweep filtering...");
+            eprintln!("[sweepga] Applying plane sweep filtering (1:1 mode)...");
         }
 
         let filter_config = FilterConfig {
@@ -151,8 +153,8 @@ impl Aligner for SweepgaAligner {
             mapping_max_per_target: Some(1),
             scoring_function: ScoringFunction::LogLengthIdentity,
             overlap_threshold: 0.95,
-            min_block_length: 100,  // Filter out very short alignments
-            scaffold_filter_mode: FilterMode::ManyToMany,  // No scaffolding
+            min_block_length: 0,  // Keep all alignments (no length filter for graph construction)
+            scaffold_filter_mode: FilterMode::ManyToMany,
             scaffold_max_per_query: None,
             scaffold_max_per_target: None,
             plane_sweep_secondaries: 0,


### PR DESCRIPTION
## Problem

SweepGA was configured with `min_block_length: 100`, which filtered out alignments shorter than 100bp. For pangenome graph construction, we need **all local matches** regardless of length, as even short matches are important for the graph structure.

## Solution

Changed `min_block_length: 0` to keep all alignments.

## How 1:1 Filtering Works

The current config correctly applies 1:1 filtering per sequence-pair (or per genome-group if using PanSN naming):

```rust
mapping_filter_mode: FilterMode::OneToOne,
prefix_delimiter: '#',
skip_prefix: false,  // DO use prefix grouping (confusing name!)
```

**With PanSN naming** (e.g., `genomeA#hap1#chr1`):
- Groups by prefix: `genomeA#hap1#`
- Applies 1:1 filtering per group-pair
- Keeps best mapping between each genome-group pair
- Allows multiple mappings per sequence across different group-pairs

**Without PanSN naming**:
- Treats each sequence as its own group
- Applies 1:1 per sequence-pair
- Keeps best mapping between each sequence pair

This is the correct behavior for graph construction - we get all pairwise alignments but with quality filtering per pair.

## Changes

- `min_block_length: 0` (was `100`)
- Improved code comments to clarify filtering behavior

## Testing

✅ Build successful  
✅ Tests pass